### PR TITLE
Update Contact Tracer package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9538,9 +9538,9 @@
       }
     },
     "react-native-contact-tracer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/react-native-contact-tracer/-/react-native-contact-tracer-1.0.3.tgz",
-      "integrity": "sha512-XCuiK+nujjp5y8/7LSrODq+ly6gNOGe1x+JPbWBR+0NJbOkj/9zWOA5WCkwlL+0U+aRo7kPctICORHg9wIhmAw=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-native-contact-tracer/-/react-native-contact-tracer-1.0.4.tgz",
+      "integrity": "sha512-1qy8CSOzjKVGPfgYzuQC5pz+89Zg3eCz2zGo1m4KuQT29EpuIFrnxpXVMi+Pi5Np3glHhYOZJzhGkP43r4U2iQ=="
     },
     "react-native-datepicker": {
       "version": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-native-circular-slider": "^1.0.1",
     "react-native-code-push": "^6.1.1",
     "react-native-config": "^1.0.0",
-    "react-native-contact-tracer": "^1.0.3",
+    "react-native-contact-tracer": "^1.0.4",
     "react-native-device-info": "^5.5.3",
     "react-native-easy-grid": "^0.2.0",
     "react-native-elements": "^1.2.7",


### PR DESCRIPTION
Update Contact Tracer to v1.0.4 to fix the crash on Android related to Bluetooth Adapter is not turned on error.