### PR TITLE
Feature/change the way to declare bluetooth UUID to prevent confliction with another code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9538,9 +9538,9 @@
       }
     },
     "react-native-contact-tracer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/react-native-contact-tracer/-/react-native-contact-tracer-1.1.6.tgz",
-      "integrity": "sha512-lj80AM0EjGmhdGUEx1DOAuUQv5K0vp/JMJ6WYvMyoJ3U1ETZKP8Dg2WIINnJBbhYO7Ty0+Gx6rYjqU3cPPYBQA=="
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-contact-tracer/-/react-native-contact-tracer-1.1.7.tgz",
+      "integrity": "sha512-+i4SPZxnhRZ3p0lDSKX62dAVC1w4vxJ5D1UiZW2QKk2tH1www37KzZ6f4ipmt/nN2qGc+q/tb2Cx6Llfqk/zaA=="
     },
     "react-native-datepicker": {
       "version": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-native-circular-slider": "^1.0.1",
     "react-native-code-push": "^6.1.1",
     "react-native-config": "^1.0.0",
-    "react-native-contact-tracer": "^1.1.6",
+    "react-native-contact-tracer": "^1.1.7",
     "react-native-device-info": "^5.5.3",
     "react-native-easy-grid": "^0.2.0",
     "react-native-elements": "^1.2.7",


### PR DESCRIPTION
Update react-native-contact-tracer to the latest version to move bluetooth UUID from module level to App level.