### PR TITLE
Fix Github Actions build-test failed on setup-node

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v2
+      with:
+        node-version: '12'
+        check-latest: true
     # Runs a set of commands using the runners shell
       
     - run: yarn install

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2
       with:
-        node-version: '12'
+        node-version: '10'
         check-latest: true
     # Runs a set of commands using the runners shell
       


### PR DESCRIPTION
From https://github.com/actions/setup-node/issues/212, Github has disabled `add-path` command that caused setup-node to fail.

This PR fixes this by upgrade actions/setup-node from v1.4.2 to v2 and still using node 10.

Now, setup-node runs passed as of this job https://github.com/wiput1999/morchana-app/runs/1663084228 but the build still failed because of prettier issue.