### PR TITLE
Fix permission denied error when picking an image from gallery in Android

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -239,8 +239,8 @@ PODS:
   - react-native-image-editor (2.3.0):
     - React
     - React-RCTImage
-  - react-native-image-picker (2.3.1):
-    - React
+  - react-native-image-picker (3.1.3):
+    - React-Core
   - react-native-maps (0.26.1):
     - React
   - react-native-restart (0.0.17):
@@ -602,7 +602,7 @@ SPEC CHECKSUMS:
   react-native-config: 7db9b96479164dfd7b2be68eb9079e08279511c4
   react-native-get-random-values: 148a42f97f2ce180a52d219144e83c278d4fe24b
   react-native-image-editor: 9361a215c3991cafbe5e7f28cbbad6e72c9c2705
-  react-native-image-picker: 6a850c41f57f0848d918c2a77aedd7aa272ffa30
+  react-native-image-picker: 98920a299f85c566800d5b0a884352504a7585eb
   react-native-maps: 6e499eee4eabf422ba8b6f94e993cc768bf35153
   react-native-restart: d19a0f8d053d065fe64cd2baebb6487111c77149
   react-native-rsa-native: 348b5057073920db0e154724c3a49e6b34e1da6b

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-native-gesture-handler": "^1.6.0",
     "react-native-get-random-values": "^1.3.0",
     "react-native-i18n": "^2.0.15",
-    "react-native-image-picker": "^2.3.1",
+    "react-native-image-picker": "^3.1.3",
     "react-native-json-tree": "^1.2.0",
     "react-native-jwt-verifier": "^1.1.1",
     "react-native-keyboard-aware-scrollview": "^2.1.0",

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -97,20 +97,8 @@ const CloseButton = ({onClose}) => (
 )
 
 const DEFAULT_OPTIONS = {
-  title: 'Select a Photo',
-  cancelButtonTitle: 'Cancel',
-  takePhotoButtonTitle: 'Take Photo…',
-  chooseFromLibraryButtonTitle: 'Choose from Library…',
+  mediaType: 'photo',
   quality: 1.0,
-  allowsEditing: false,
-  permissionDenied: {
-    title: 'Permission denied',
-    text:
-      'To be able to take pictures with your camera and choose images from your library.',
-    reTryTitle: 're-try',
-    okTitle: "I'm sure",
-  },
-  tintColor: '',
 }
 
 const isImagePickerAvailable = Boolean(NativeModules.ImagePickerManager)
@@ -118,7 +106,7 @@ const SelectImageButton = ({onSelectImage}) => {
   if (!isImagePickerAvailable) {
     return null
   }
-  const ImagePicker = require('react-native-image-picker').default
+  const ImagePicker = require('react-native-image-picker')
   const options = {
     ...DEFAULT_OPTIONS,
     title: 'Select Avatar',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8058,10 +8058,10 @@ react-native-i18n@^2.0.15:
   dependencies:
     i18n-js "3.0.11"
 
-react-native-image-picker@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-2.3.1.tgz#1977b65e07793d2c0b2d1976fb675c5f75ad7f11"
-  integrity sha512-c/a2h7/T7yBo5KlNQhcSn4xf4+6Li6LfJ59+GZT1ZzzWrj/6X8DiJ/TJBOlOZMC5tJriZKuRkWSsr74k6z+brw==
+react-native-image-picker@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-3.1.3.tgz#88e747d010c4095febb0797d895b80c0c25b114f"
+  integrity sha512-3T4sVBBhGhNoVW7x7lqyxOENNUbBTu68yGTDQUWd8VQHA6EezAcV+4ixOxD2VyeLMDGj/Ar3O+siaC5F45Y7YA==
 
 react-native-input-xg@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
# The current behavior
Tested on MorChana 2.0.2 on Google Pixel Android 10.
1. Uninstall and reinstall the app
2. Press "ลงทะเบียน" > ยอมรับ > ถ่ายรูป
3. Allow camera permission when prompted
4. In camera view, press gallery button in the bottom right corner.
![device-2021-01-13-153006](https://user-images.githubusercontent.com/10735822/104426611-bf7c4a00-55b4-11eb-8caf-1068a8929679.png)
5. Allow storage permission when prompted
6. Select a photo from internal storage using image picker
7. The app goes back to profile picture onboard screen, but the selected photo does not replace the placeholder image. 
![device-2021-01-13-153042](https://user-images.githubusercontent.com/10735822/104426673-d15ded00-55b4-11eb-941f-17a434f37e12.png)

# The expected behavior
The selected photo replaces the placeholder image and ถัดไป button becomes enabled.

# Problem discussion
Logcat shows following error after image selection finishes:
```
W/System.err: java.io.FileNotFoundException: /storage/emulated/0/DCIM/Camera/IMG_20210110_204657.jpg: open failed: EACCES (Permission denied)
```
This problem is caused by recent change to target API level from 28 to 29 since app version 2.x. Apps targeting Android 10 or higher are enforced by [scoped storage](https://developer.android.com/training/data-storage#scoped-storage), which only allows access to app-specific directory on external storage regardless to READ_EXTERNAL_STORAGE permission. The issue [was addressed](https://github.com/react-native-image-picker/react-native-image-picker/commit/13861fa9a5d5bf9de9c7a119ea7ff6027d90f406) in version 3.1.0 of react-native-image-picker. Therefore, upgrading the library to the latest version fixes the problem.

# About this change
This change upgrades react-native-image-picker to the latest version (3.1.3) and updates the image picker code to comply the current API. With this change applied, the image picker result would be as the expected behavior described.

Tested on Google Pixel (Android 10), Samsung Galaxy A50s (Android 10), Samsung Galaxy S5 (Android 6.0.1), and iPhone 11 Pro simulator (iOS 14.1).