### PR TITLE
Huawei HMS- Remove 'Require GMS' dialog for HMS phone user

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -232,6 +232,10 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'
     implementation 'com.google.firebase:firebase-analytics:17.3.0'
+
+    implementation 'com.huawei.hms:hwid:4.0.1.300'
+    implementation 'com.google.android.gms:play-services-auth:17.0.0'
+
 }
 
 // Run this once to be able to run the application with BUCK
@@ -243,5 +247,5 @@ task copyDownloadableDepsToLibs(type: Copy) {
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
 apply plugin: 'com.google.gms.google-services'
-
+apply plugin: 'com.huawei.agconnect'
 

--- a/android/app/src/main/java/com/thaialert/app/MainApplication.java
+++ b/android/app/src/main/java/com/thaialert/app/MainApplication.java
@@ -19,6 +19,9 @@ import com.microsoft.codepush.react.CodePush;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
+import com.thaialert.app.RNHmsPackage;
+
+
 public class MainApplication extends Application implements ReactApplication {
 
     private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
@@ -36,6 +39,8 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
             @SuppressWarnings("UnnecessaryLocalVariable")
             List<ReactPackage> packages = new PackageList(this).getPackages();
+            packages.add(new RNHmsPackage());
+
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // packages.add(new ReactNativePushNotificationPackage());
             return packages;

--- a/android/app/src/main/java/com/thaialert/app/RNHmsBase.java
+++ b/android/app/src/main/java/com/thaialert/app/RNHmsBase.java
@@ -1,0 +1,62 @@
+package com.thaialert.app;
+
+import android.widget.Toast;
+import android.content.Context; 
+import android.util.Log;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import com.huawei.hms.api.HuaweiApiAvailability;
+import com.google.android.gms.common.GoogleApiAvailability;
+
+public class RNHmsBase extends ReactContextBaseJavaModule {
+
+    public RNHmsBase(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    // ReactContextBaseJavaModule requires derived class implement getName method. This function returns a string.
+    // This string is used to tag the native module on the JavaScript side
+    @Override
+    public String getName() {
+        return "HMSBase";
+    }
+
+    // Gets the application package name
+    // To export a method for JavaScript use, Java methods need to use the @reactmethod annotation
+    @ReactMethod
+    public void getPackageName() {
+        Toast.makeText(getReactApplicationContext(),"RNHMSBase has been called",Toast.LENGTH_LONG).show();
+    }
+    
+    // Check is the device support HMS service 
+    // To export a method for JavaScript use, Java methods need to use the @reactmethod annotation
+    @ReactMethod
+    public boolean isHmsAvailable() { 
+        boolean isAvailable = false; 
+        Context context = getReactApplicationContext();
+        if (null != context) { 
+            int result = HuaweiApiAvailability.getInstance().isHuaweiMobileServicesAvailable(context); 
+            isAvailable = (com.huawei.hms.api.ConnectionResult.SUCCESS == result); 
+        } 
+        Log.i("React", "isHmsAvailable: " + isAvailable); 
+        return isAvailable; 
+    }
+
+    // Check is the device support GMS service 
+    // To export a method for JavaScript use, Java methods need to use the @reactmethod annotation
+    @ReactMethod
+    public boolean isGmsAvailable() {
+        boolean isAvailable = false; 
+        Context context = getReactApplicationContext();
+        if (null != context) {
+            int result = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context); 
+            isAvailable = (com.google.android.gms.common.ConnectionResult.SUCCESS == result);
+        } 
+        Log.i("React", "isGmsAvailable: " + isAvailable);
+        return isAvailable;
+    }
+
+}

--- a/android/app/src/main/java/com/thaialert/app/RNHmsPackage.java
+++ b/android/app/src/main/java/com/thaialert/app/RNHmsPackage.java
@@ -1,0 +1,25 @@
+package com.thaialert.app;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class RNHmsPackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new RNHmsBase(reactContext));
+        return modules;
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,10 +20,12 @@ buildscript {
         jcenter()
         google()
         maven { url 'https://jitpack.io' }
+        maven { url 'https://developer.huawei.com/repo/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
         classpath('com.google.gms:google-services:4.3.3')
+         classpath 'com.huawei.agconnect:agcp:1.2.0.300' 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -34,6 +36,7 @@ allprojects {
         google()
         jcenter()
         maven { url "https://jitpack.io" }
+        maven { url 'https://developer.huawei.com/repo/' }
         maven {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")

--- a/src/navigations/2-Onboarding/OnboardLocation.tsx
+++ b/src/navigations/2-Onboarding/OnboardLocation.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react'
+import { NativeModules } from 'react-native';
+
 import {
   ActivityIndicator,
   Image,
@@ -45,7 +47,9 @@ export const OnboardLocation = () => {
       check(ACTIVITY_PERMISSION),
     ])
     if (perms[0] === 'granted' && perms[1] === 'granted') {
-      await backgroundTracking.start()
+      if(Platform.OS === 'ios' ||  NativeModules.HMSBase.isGmsAvailable() === true){
+        backgroundTracking.start()
+      }
       navigation.navigate('OnboardProgressing')
     } else {
       setLocationPerm(perms[0])
@@ -60,12 +64,16 @@ export const OnboardLocation = () => {
   const handleSubmit = async () => {
     showSpinner()
 
+    //this does not request location for android
     await request(LOCATION_PERMISSION)
     await request(ACTIVITY_PERMISSION)
 
     hide()
-
-    backgroundTracking.start()
+    //this will request location, but for non-gms phone will see the 'Require GMS Dialog
+    //this is being remove also because non-gms can not retrieve location from GMS anyway
+    if(Platform.OS === 'ios' ||  NativeModules.HMSBase.isGmsAvailable() === true){
+      backgroundTracking.start()
+    }
 
     setTimeout(() => {
       navigation.navigate('OnboardBluetooth')


### PR DESCRIPTION
This version only remove the dialog "GMS unavailable" from onboarding stage. Not in the mainpage, since that have to fix the location issue and might effect alot of code. What I did

1. Add Native module to check for HMS and GMS phone
 2. The dialog come from the method backgroundTracking.start()
3. I cover the method checking if the phone is IOS or having GMS in the android phone to use the method
4. Requesting background location somehow didnt work in request method, this also doesnt work in normal build. But 'backgroundTracking.start() is requesting it.
5. HMS phone will not be requesting for location